### PR TITLE
Fix dm_motor MoveIt dependency

### DIFF
--- a/src/dm_motor/package.xml
+++ b/src/dm_motor/package.xml
@@ -52,6 +52,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>roslib</build_depend>
   <build_depend>message_generation</build_depend>
+  <build_depend>moveit_ros_planning_interface</build_depend>
   
   <!-- The export tag contains other, unspecified, tags -->
   <export>
@@ -61,4 +62,6 @@
   <build_export_depend>message_generation</build_export_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>roslib</exec_depend>
-  <exec_depend>message_runtime</exec_depend></package>
+  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>moveit_ros_planning_interface</exec_depend>
+</package>


### PR DESCRIPTION
## Summary
- add missing `moveit_ros_planning_interface` dependency in `dm_motor` package

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_686f89aeb62c8329928648177ea4fdfb